### PR TITLE
Add Qwen 3 models from Fireworks AI

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -77,6 +77,18 @@
       "provider": "Fireworks",
       "providerId": "fireworks",
       "name": "DeepSeek R1"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen3-30b-a3b",
+      "provider": "Fireworks",
+      "providerId": "fireworks",
+      "name": "Qwen3 30B-A3B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen3-235b-a22b",
+      "provider": "Fireworks",
+      "providerId": "fireworks",
+      "name": "Qwen3 235B-A22B"
     }
   ]
 }


### PR DESCRIPTION
This commit adds the following Qwen 3 models, available on Fireworks AI, to the list of supported models:
- Qwen3 30B-A3B
- Qwen3 235B-A22B

The `lib/models.json` file has been updated with these new model definitions. The existing UI component for model selection is expected to display these new models without requiring code changes.