### PR TITLE
Recommended bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "echarts": "^5.5.1",
         "echarts-for-react": "^3.0.2",
         "lucide-react": "^0.453.0",
-        "next": "14.2.33",
+        "next": "^14.2.34",
         "ollama-ai-provider": "^0.16.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -757,10 +757,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
-      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==",
-      "license": "MIT"
+      "version": "14.2.34",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.34.tgz",
+      "integrity": "sha512-iuGW/UM+EZbn2dm+aLx+avo1rVap+ASoFr7oLpTBVW2G2DqhD5l8Fme9IsLZ6TTsp0ozVSFswidiHK1NGNO+pg=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.33",
@@ -5826,12 +5825,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
-      "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
-      "license": "MIT",
+      "version": "14.2.34",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.34.tgz",
+      "integrity": "sha512-s7mRraWlkEVRLjHHdu5khn0bSnmUh+U+YtigBc+t2Ge7jJHFIVBZna+W9Jcx7b04HhM7eJWrNJ2A+sQs9gJ3eg==",
       "dependencies": {
-        "@next/env": "14.2.33",
+        "@next/env": "14.2.34",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "echarts": "^5.5.1",
     "echarts-for-react": "^3.0.2",
     "lucide-react": "^0.453.0",
-    "next": "14.2.33",
+    "next": "^14.2.34",
     "ollama-ai-provider": "^0.16.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade Next.js to 14.2.34 with corresponding lockfile and @next/env updates.
> 
> - **Dependencies**:
>   - Bump `next` to `^14.2.34` in `package.json` and `package-lock.json`.
>   - Update transitive `@next/env` to `14.2.34`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dc42baa6a2548fbb20c3cfa46246057000dfbca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->